### PR TITLE
docs: Fix simple typo, dissmiss -> dismiss

### DIFF
--- a/dist/atv.js
+++ b/dist/atv.js
@@ -28030,7 +28030,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var hrefAttribute = 'data-href-page';
 	var hrefOptionsAttribute = 'data-href-page-options';
 	var hrefPageReplaceAttribute = 'data-href-page-replace';
-	var modalCloseBtnAttribute = 'data-alert-dissmiss';
+	var modalCloseBtnAttribute = 'data-alert-dismiss';
 	var menuItemReloadAttribute = 'reloadOnSelect';
 
 	/**
@@ -28093,7 +28093,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	         *              
 	         *              ...
 	         *
-	         *              <button data-alert-dissmiss="close">
+	         *              <button data-alert-dismiss="close">
 	         *                  <text>Cancel</text>
 	         *              </button>
 	         *              
@@ -28139,12 +28139,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	                            element.pageDoc = doc;
 	                            _menu2.default.setDocument(doc, menuId);
 	                        }
-	                        // dissmiss any open modals
+	                        // dismiss any open modals
 	                        _navigation2.default.dismissModal();
 	                    }, function (error) {
 	                        // if there was an error loading the page, set an error page to the menu item
 	                        _menu2.default.setDocument(_navigation2.default.getErrorDoc(error), menuId);
-	                        // dissmiss any open modals
+	                        // dismiss any open modals
 	                        _navigation2.default.dismissModal();
 	                    });
 	                }

--- a/src/handler.js
+++ b/src/handler.js
@@ -5,7 +5,7 @@ import Menu from './menu';
 const hrefAttribute = 'data-href-page';
 const hrefOptionsAttribute = 'data-href-page-options';
 const hrefPageReplaceAttribute = 'data-href-page-replace';
-const modalCloseBtnAttribute = 'data-alert-dissmiss';
+const modalCloseBtnAttribute = 'data-alert-dismiss';
 const menuItemReloadAttribute = 'reloadOnSelect';
 
 /**
@@ -67,7 +67,7 @@ let handlers = {
          *              
          *              ...
          *
-         *              <button data-alert-dissmiss="close">
+         *              <button data-alert-dismiss="close">
          *                  <text>Cancel</text>
          *              </button>
          *              
@@ -112,12 +112,12 @@ let handlers = {
                             element.pageDoc = doc;
                             Menu.setDocument(doc, menuId);    
                         }
-                        // dissmiss any open modals
+                        // dismiss any open modals
                         Navigation.dismissModal();
                     }, (error) => {
                         // if there was an error loading the page, set an error page to the menu item
                         Menu.setDocument(Navigation.getErrorDoc(error), menuId);
-                        // dissmiss any open modals
+                        // dismiss any open modals
                         Navigation.dismissModal();
                     });
                 }


### PR DESCRIPTION
There is a small typo in dist/atv.js, src/handler.js.

Should read `dismiss` rather than `dissmiss`.

